### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,12 +12,12 @@ ShiftBrite	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init		KEYWORD2
-set		KEYWORD2
-setAll          KEYWORD2
-update		KEYWORD2
-clear		KEYWORD2
-length          KEYWORD2
+init	KEYWORD2
+set	KEYWORD2
+setAll	KEYWORD2
+update	KEYWORD2
+clear	KEYWORD2
+length	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -29,4 +29,4 @@ shiftbrite	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-NUM_LEDS        LITERAL1
+NUM_LEDS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords